### PR TITLE
Fixes aspectmock include paths

### DIFF
--- a/test/MyClassTest.php
+++ b/test/MyClassTest.php
@@ -36,7 +36,7 @@ class MyClassTest extends PHPUnit_Framework_TestCase{
 			'debug' => true,
 			//'appDir' => __DIR__ . '../',
 			'includePaths' => [
-				__DIR__.'../src/',
+				__DIR__.'/../src/',
 				//__DIR__.'../vendor/',
 			],
 			'excludePaths' => [

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -6,10 +6,10 @@ $kernel = \AspectMock\Kernel::getInstance();
 $kernel->init([
 	'debug' => true,
 	'includePaths' => [
-		__DIR__.'../src/'
+		__DIR__.'/../src/'
 	],
 	'excludePaths' => [
-		__DIR__.'../vendor', 
+		__DIR__.'/../vendor', 
 		__DIR__
 	]
 ]);


### PR DESCRIPTION
you're missing `'/'` in front of `../` , Your tests will now working:

``` bash
$ vendor/bin/phpunit test/
PHPUnit 3.7.38 by Sebastian Bergmann.

.

Time: 113 ms, Memory: 6.00Mb

OK (1 test, 1 assertion)
```
